### PR TITLE
Fix: search param min length

### DIFF
--- a/backend/schemas/__init__.py
+++ b/backend/schemas/__init__.py
@@ -78,7 +78,7 @@ class PaginationParams(BaseModel):
     limit: int = Field(20, ge=1, le=100)
     sort: Literal["created_at", "likes"] = Field("created_at")
     order: Literal["asc", "desc"] = Field("desc")
-    search: Optional[str] = Field(None, min_length=1, max_length=50)
+    search: Optional[str] = Field(None, min_length=2, max_length=50)
 
 
 class PublicPaginationParams(PaginationParams):


### PR DESCRIPTION
В файле schemas/__init__.py в PaginationParams у поля search min_length изменён с 1 на 2 для соответствия требованиям F_Search_1-3

Closes #91 