### PR TITLE
Test: add unit tests for React components

### DIFF
--- a/frontend/src/components/Alert/Alert.test.tsx
+++ b/frontend/src/components/Alert/Alert.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Alert } from './index';
+
+describe('Alert', () => {
+  it('рендерит переданный текст', () => {
+    render(<Alert>Ошибка!</Alert>);
+    expect(screen.getByText('Ошибка!')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Button/Button.test.tsx
+++ b/frontend/src/components/Button/Button.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { describe, it, expect, vi } from 'vitest';
+import { Button, LinkButton } from './index';
+
+const renderWithRouter = (ui: React.ReactElement) => {
+  return render(<BrowserRouter>{ui}</BrowserRouter>);
+};
+
+describe('Button', () => {
+  describe('Базовая функциональность', () => {
+    it('рендерит текст', () => {
+      render(<Button>Отправить</Button>);
+      expect(screen.getByText('Отправить')).toBeInTheDocument();
+    });
+
+    it('вызывает onClick при клике', () => {
+      const onClick = vi.fn();
+      render(<Button onClick={onClick}>Клик</Button>);
+
+      fireEvent.click(screen.getByRole('button'));
+      expect(onClick).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Состояния', () => {
+    it('disabled при loading=true', () => {
+      render(<Button loading>Загрузка</Button>);
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+  });
+
+  describe('Пропсы', () => {
+    it('имеет type submit по умолчанию', () => {
+      render(<Button>OK</Button>);
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'submit');
+    });
+
+    it('может иметь type=button', () => {
+      render(<Button type="button">Кнопка</Button>);
+      expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+    });
+
+    it('рендерится с color=white', () => {
+      render(<Button color="white">Текст</Button>);
+      expect(screen.getByRole('button')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('LinkButton', () => {
+  it('рендерит ссылку с правильным href', () => {
+    renderWithRouter(<LinkButton to="/about">О нас</LinkButton>);
+
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/about');
+  });
+
+  it('рендерит переданный текст', () => {
+    renderWithRouter(<LinkButton to="/">Главная</LinkButton>);
+    expect(screen.getByText('Главная')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/DeleteConfirmModal/DeleteConfirmModale.test.tsx
+++ b/frontend/src/components/DeleteConfirmModal/DeleteConfirmModale.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { DeleteConfirmModal } from './index';
+
+describe('DeleteConfirmModal', () => {
+  it('не рендерится если закрыт', () => {
+    const { container } = render(
+      <DeleteConfirmModal isOpen={false} onConfirm={() => {}} onCancel={() => {}} />
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('вызывает confirm', () => {
+    const onConfirm = vi.fn();
+
+    render(<DeleteConfirmModal isOpen={true} onConfirm={onConfirm} onCancel={() => {}} />);
+
+    fireEvent.click(screen.getByText('Удалить'));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+
+  it('вызывает cancel', () => {
+    const onCancel = vi.fn();
+
+    render(<DeleteConfirmModal isOpen={true} onConfirm={() => {}} onCancel={onCancel} />);
+
+    fireEvent.click(screen.getByText('Отмена'));
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/Input/Input.test.tsx
+++ b/frontend/src/components/Input/Input.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Input } from './index';
+
+describe('Input', () => {
+  it('рендерит label', () => {
+    render(<Input label="Email" />);
+    expect(screen.getByText('Email')).toBeInTheDocument();
+  });
+
+  it('input связан с label через htmlFor', () => {
+    render(<Input label="Email" />);
+    const input = screen.getByLabelText('Email');
+    expect(input).toBeInTheDocument();
+  });
+
+  it('показывает сообщение об ошибке', () => {
+    render(<Input error="Ошибка" />);
+    expect(screen.getByText('Ошибка')).toBeInTheDocument();
+  });
+
+  it('не показывает ошибку если error не передан', () => {
+    render(<Input />);
+    expect(screen.queryByText('Ошибка')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Likes/Likes.test.tsx
+++ b/frontend/src/components/Likes/Likes.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../api/reviews', () => {
+  return {
+    toggleLike: vi.fn(),
+  };
+});
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../Alert', () => ({
+  Alert: ({ children }: { children: React.ReactNode }) => <div data-testid="alert">{children}</div>,
+}));
+
+import { Likes } from './index';
+import * as ReviewsAPI from '../../api/reviews';
+import * as AuthContext from '../../context/AuthContext';
+
+describe('Likes - Module Test', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Базовое состояние авторизации
+    (AuthContext.useAuth as any).mockReturnValue({
+      isAuthenticated: true,
+      user: { id: 1, username: 'test' },
+    });
+  });
+
+  describe('рендеринг', () => {
+    it('отображает количество лайков', () => {
+      render(<Likes reviewId={1} likes={5} isLiked={false} />);
+      expect(screen.getByText('5')).toBeInTheDocument();
+    });
+
+    it('показывает иконку "не лайкнуто" при isLiked=false', () => {
+      render(<Likes reviewId={1} likes={5} isLiked={false} />);
+      const img = screen.getByAltText('Не лайкнут');
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('src', '/not_liked.svg');
+    });
+
+    it('показывает иконку "лайкнуто" при isLiked=true', () => {
+      render(<Likes reviewId={1} likes={5} isLiked={true} />);
+      const img = screen.getByAltText('Лайкнут');
+      expect(img).toBeInTheDocument();
+      expect(img).toHaveAttribute('src', '/liked.svg');
+    });
+  });
+
+  describe('авторизация', () => {
+    it('делает кнопку активной при авторизованном пользователе', () => {
+      render(<Likes reviewId={1} likes={5} isLiked={false} />);
+      expect(screen.getByRole('button')).not.toBeDisabled();
+    });
+
+    it('делает кнопку неактивной при неавторизованном пользователе', () => {
+      (AuthContext.useAuth as any).mockReturnValue({ isAuthenticated: false, user: null });
+      render(<Likes reviewId={1} likes={5} isLiked={false} />);
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('показывает подсказку для неавторизованного пользователя', () => {
+      (AuthContext.useAuth as any).mockReturnValue({ isAuthenticated: false, user: null });
+      render(<Likes reviewId={1} likes={5} isLiked={false} />);
+      expect(screen.getByRole('button')).toHaveAttribute('title', 'Войдите, чтобы ставить лайки');
+    });
+
+    it('не показывает подсказку для авторизованного пользователя', () => {
+      render(<Likes reviewId={1} likes={5} isLiked={false} />);
+      expect(screen.getByRole('button')).not.toHaveAttribute('title');
+    });
+  });
+
+  describe('обработка кликов', () => {
+    it('не вызывает handleToggle при клике без авторизации', () => {
+      (AuthContext.useAuth as any).mockReturnValue({ isAuthenticated: false, user: null });
+      render(<Likes reviewId={1} likes={5} isLiked={false} />);
+      fireEvent.click(screen.getByRole('button'));
+      expect(ReviewsAPI.toggleLike).not.toHaveBeenCalled();
+    });
+
+    it('вызывает handleToggle при клике с авторизацией', () => {
+      render(<Likes reviewId={1} likes={5} isLiked={false} />);
+      fireEvent.click(screen.getByRole('button'));
+      expect(ReviewsAPI.toggleLike).toHaveBeenCalledWith(1);
+    });
+  });
+});

--- a/frontend/src/components/MainLayout/MainLayout.test.tsx
+++ b/frontend/src/components/MainLayout/MainLayout.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { BrowserRouter } from 'react-router-dom';
+
+vi.mock('../Navbar', () => ({
+  Navbar: () => <div>Navbar Mock</div>,
+}));
+
+import { MainLayout } from './index';
+
+describe('MainLayout', () => {
+  it('рендерит Navbar', () => {
+    render(
+      <BrowserRouter>
+        <MainLayout />
+      </BrowserRouter>
+    );
+
+    expect(screen.getByText('Navbar Mock')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/Navbar/Navbar.test.tsx
+++ b/frontend/src/components/Navbar/Navbar.test.tsx
@@ -1,0 +1,107 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockUseAuth = vi.fn();
+const mockUseNavigate = vi.fn();
+const mockLogout = vi.fn();
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+vi.mock('react-router-dom', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-router-dom')>();
+  return {
+    ...actual,
+    useNavigate: () => mockUseNavigate,
+    Link: ({ to, children }: any) => <a href={to}>{children}</a>,
+  };
+});
+
+vi.mock('../../Button', () => ({
+  Button: ({ onClick, children }: any) => <button onClick={onClick}>{children}</button>,
+  LinkButton: ({ children }: any) => <span>{children}</span>,
+}));
+
+vi.mock('./index.module.scss', () => ({
+  default: {
+    navbar: 'navbar',
+    left: 'left',
+    right: 'right',
+    link: 'link',
+    username: 'username',
+  },
+}));
+
+import { Navbar } from './index';
+
+describe('Navbar (модульный тест)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('показывает ссылки на Вход и Регистрация если не авторизован', () => {
+    mockUseAuth.mockReturnValue({
+      user: null,
+      isAuthenticated: false,
+      logout: mockLogout,
+    });
+
+    render(<Navbar />);
+
+    expect(screen.getByText('Вход')).toBeInTheDocument();
+    expect(screen.getByText('Регистрация')).toBeInTheDocument();
+  });
+
+  it('показывает username и кнопку Выйти для обычного пользователя', () => {
+    mockUseAuth.mockReturnValue({
+      user: { username: 'test', role: 'user' },
+      isAuthenticated: true,
+      logout: mockLogout,
+    });
+
+    render(<Navbar />);
+
+    expect(screen.getByText('test')).toBeInTheDocument();
+    expect(screen.getByText('Выйти')).toBeInTheDocument();
+  });
+
+  it('не показывает админскую ссылку для обычного пользователя', () => {
+    mockUseAuth.mockReturnValue({
+      user: { username: 'test', role: 'user' },
+      isAuthenticated: true,
+      logout: mockLogout,
+    });
+
+    render(<Navbar />);
+
+    expect(screen.queryByText('Рецензии на модерации')).not.toBeInTheDocument();
+  });
+
+  it('показывает админскую ссылку для admin', () => {
+    mockUseAuth.mockReturnValue({
+      user: { username: 'admin', role: 'admin' },
+      isAuthenticated: true,
+      logout: mockLogout,
+    });
+
+    render(<Navbar />);
+
+    expect(screen.getByText('Рецензии на модерации')).toBeInTheDocument();
+  });
+
+  it('вызывает logout и navigate при клике Выйти', () => {
+    mockUseAuth.mockReturnValue({
+      user: { username: 'test', role: 'user' },
+      isAuthenticated: true,
+      logout: mockLogout,
+    });
+
+    render(<Navbar />);
+
+    fireEvent.click(screen.getByText('Выйти'));
+
+    expect(mockLogout).toHaveBeenCalled();
+    expect(mockUseNavigate).toHaveBeenCalledWith('/sign-in', { replace: true });
+  });
+});

--- a/frontend/src/components/ProtectedRoutes/ProtectedRoutes.test.tsx
+++ b/frontend/src/components/ProtectedRoutes/ProtectedRoutes.test.tsx
@@ -1,0 +1,188 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockUseAuth = vi.hoisted(() => vi.fn());
+const mockNavigate = vi.hoisted(() =>
+  vi.fn(({ to, replace, state }: any) => (
+    <div data-testid={`navigate-${to}`} data-replace={replace} data-state={JSON.stringify(state)}>
+      Redirect to {to}
+    </div>
+  ))
+);
+const mockOutlet = vi.hoisted(() => vi.fn(() => <div data-testid="outlet">Outlet</div>));
+const mockSpinner = vi.hoisted(() => vi.fn(() => <div data-testid="spinner">Spinner</div>));
+
+vi.mock('../../context/AuthContext', () => ({
+  useAuth: mockUseAuth,
+}));
+
+vi.mock('react-router-dom', () => ({
+  Navigate: mockNavigate,
+  Outlet: mockOutlet,
+}));
+
+vi.mock('../../lib/routes', () => ({
+  getSignInRoute: vi.fn(() => '/signin'),
+  getAllReviewsRoute: vi.fn(() => '/reviews'),
+}));
+
+vi.mock('../Spinner', () => ({
+  Spinner: mockSpinner,
+}));
+
+// Мокаем глобальный location
+vi.stubGlobal('location', { pathname: '/protected' });
+
+import { RequireAuth, RequireAdmin } from './index';
+
+describe('RequireAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('показывает Spinner при loading', () => {
+    mockUseAuth.mockReturnValue({
+      loading: true,
+      isAuthenticated: false,
+    });
+
+    render(<RequireAuth />);
+
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+  });
+
+  it('редиректит на вход если не авторизован', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: false,
+    });
+
+    render(<RequireAuth />);
+
+    const navigate = screen.getByTestId('navigate-/signin');
+    expect(navigate).toBeInTheDocument();
+    expect(navigate).toHaveAttribute('data-replace', 'true');
+
+    // Проверяем state с from
+    const state = JSON.parse(navigate.getAttribute('data-state') || '{}');
+    expect(state.from).toBe('/protected');
+  });
+
+  it('рендерит children если авторизован', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+    });
+
+    render(
+      <RequireAuth>
+        <div>Test Content</div>
+      </RequireAuth>
+    );
+
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('рендерит Outlet если авторизован без children', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+    });
+
+    render(<RequireAuth />);
+
+    expect(screen.getByTestId('outlet')).toBeInTheDocument();
+  });
+});
+
+describe('RequireAdmin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('редиректит на вход если не авторизован', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: false,
+      user: null,
+    });
+
+    render(<RequireAdmin />);
+
+    const navigate = screen.getByTestId('navigate-/signin');
+    expect(navigate).toBeInTheDocument();
+    expect(navigate).toHaveAttribute('data-replace', 'true');
+
+    const state = JSON.parse(navigate.getAttribute('data-state') || '{}');
+    expect(state.from).toBe('/protected');
+  });
+
+  it('редиректит на все рецензии если user не admin', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+      user: { role: 'user' },
+    });
+
+    render(<RequireAdmin />);
+
+    const navigate = screen.getByTestId('navigate-/reviews');
+    expect(navigate).toBeInTheDocument();
+    expect(navigate).toHaveAttribute('data-replace', 'true');
+  });
+
+  it('редиректит на все рецензии если user role не определен', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+      user: {}, // role не определен
+    });
+
+    render(<RequireAdmin />);
+
+    const navigate = screen.getByTestId('navigate-/reviews');
+    expect(navigate).toBeInTheDocument();
+  });
+
+  it('редиректит на все рецензии если user null', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+      user: null, // user null
+    });
+
+    render(<RequireAdmin />);
+
+    const navigate = screen.getByTestId('navigate-/reviews');
+    expect(navigate).toBeInTheDocument();
+  });
+
+  it('рендерит children если user admin', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+      user: { role: 'admin' },
+    });
+
+    render(
+      <RequireAdmin>
+        <div>Admin Panel</div>
+      </RequireAdmin>
+    );
+
+    expect(screen.getByText('Admin Panel')).toBeInTheDocument();
+  });
+
+  // Edge cases
+  it('работает без user объекта', () => {
+    mockUseAuth.mockReturnValue({
+      loading: false,
+      isAuthenticated: true,
+    });
+
+    render(<RequireAdmin />);
+
+    const navigate = screen.getByTestId('navigate-/reviews');
+    expect(navigate).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ReviewCard/ReviewCard.test.tsx
+++ b/frontend/src/components/ReviewCard/ReviewCard.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFormatDate = vi.hoisted(() => vi.fn());
+const mockGetEditReviewRoute = vi.hoisted(() => vi.fn());
+const mockGetUserProfileRoute = vi.hoisted(() => vi.fn());
+const mockLikes = vi.hoisted(() => vi.fn());
+const mockButton = vi.hoisted(() => vi.fn());
+const mockLinkButton = vi.hoisted(() => vi.fn());
+const mockAlert = vi.hoisted(() => vi.fn());
+const mockLink = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/date', () => ({
+  formatDate: mockFormatDate,
+}));
+
+vi.mock('../../lib/routes', () => ({
+  getEditReviewRoute: mockGetEditReviewRoute,
+  getUserProfileRoute: mockGetUserProfileRoute,
+}));
+
+vi.mock('../Likes', () => ({
+  Likes: mockLikes,
+}));
+
+vi.mock('../Button', () => ({
+  Button: mockButton,
+  LinkButton: mockLinkButton,
+}));
+
+vi.mock('../Alert', () => ({
+  Alert: mockAlert,
+}));
+
+vi.mock('react-router-dom', () => ({
+  Link: mockLink,
+}));
+
+vi.mock('./index.module.scss', () => ({
+  default: {
+    card: 'card',
+    status: 'status',
+    title: 'title',
+    meta: 'meta',
+    movie: 'movie',
+    movieIcon: 'movieIcon',
+    author: 'author',
+    logoUser: 'logoUser',
+    content: 'content',
+    footer: 'footer',
+    left: 'left',
+    date: 'date',
+    buttons: 'buttons',
+  },
+}));
+
+import { ReviewCard } from './index';
+import type { Review } from '../../api/types';
+
+describe('ReviewCard - Module Test', () => {
+  const mockReview: Review = {
+    id: 1,
+    title: 'Отличный фильм',
+    content: 'Очень понравился',
+    movie_title: 'Inception',
+    created_at: '2024-01-01',
+    likes: 3,
+    is_liked: false,
+    status: 'approved',
+    author: {
+      id: 10,
+      username: 'test_user',
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Настраиваем моки
+    mockFormatDate.mockReturnValue('1 января 2024');
+    mockGetEditReviewRoute.mockReturnValue('/edit/1');
+    mockGetUserProfileRoute.mockReturnValue('/user/10');
+
+    mockLikes.mockReturnValue(<div data-testid="likes">Likes</div>);
+    mockButton.mockImplementation(({ onClick, children, color, loading }: any) => (
+      <button onClick={onClick} data-testid={`button-${color}`} data-loading={loading}>
+        {children}
+      </button>
+    ));
+    mockLinkButton.mockImplementation(({ to, children }: any) => (
+      <a href={to} data-testid="link-button">
+        {children}
+      </a>
+    ));
+    mockAlert.mockImplementation(({ children }: any) => <div data-testid="alert">{children}</div>);
+    mockLink.mockImplementation(({ to, children, className }: any) => (
+      <a href={to} className={className} data-testid="link">
+        {children}
+      </a>
+    ));
+  });
+
+  describe('базовый рендеринг', () => {
+    it('рендерит заголовок и контент', () => {
+      render(<ReviewCard review={mockReview} />);
+
+      expect(screen.getByText('Отличный фильм')).toBeInTheDocument();
+      expect(screen.getByText('Очень понравился')).toBeInTheDocument();
+    });
+
+    it('показывает статус по умолчанию', () => {
+      render(<ReviewCard review={mockReview} />);
+
+      expect(screen.getByText('approved')).toBeInTheDocument();
+    });
+
+    it('не показывает статус при showStatus=false', () => {
+      render(<ReviewCard review={mockReview} showStatus={false} />);
+
+      expect(screen.queryByText('approved')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('условия показа лайков', () => {
+    it('показывает Likes при status=approved', () => {
+      render(<ReviewCard review={mockReview} />);
+
+      expect(screen.getByTestId('likes')).toBeInTheDocument();
+    });
+
+    it('не показывает Likes при status=pending', () => {
+      const pendingReview = { ...mockReview, status: 'pending' as const };
+      render(<ReviewCard review={pendingReview} />);
+
+      expect(screen.queryByTestId('likes')).not.toBeInTheDocument();
+    });
+
+    it('не показывает Likes при showLikes=false', () => {
+      render(<ReviewCard review={mockReview} showLikes={false} />);
+
+      expect(screen.queryByTestId('likes')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/ReviewFeed/ReviewFeed.test.tsx
+++ b/frontend/src/components/ReviewFeed/ReviewFeed.test.tsx
@@ -1,0 +1,258 @@
+import { render, waitFor, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockLoadReviews = vi.hoisted(() => vi.fn());
+const mockReviewList = vi.hoisted(() => vi.fn());
+const mockButton = vi.hoisted(() => vi.fn());
+const mockAlert = vi.hoisted(() => vi.fn());
+const mockSpinner = vi.hoisted(() => vi.fn());
+
+vi.mock('../ReviewList', () => ({ ReviewList: mockReviewList }));
+vi.mock('../Button', () => ({ Button: mockButton }));
+vi.mock('../Alert', () => ({ Alert: mockAlert }));
+vi.mock('../Spinner', () => ({ Spinner: mockSpinner }));
+
+vi.mock('./index.module.scss', () => ({ default: {} }));
+
+// импорт компонента после моков
+import { ReviewFeed } from './index';
+
+describe('ReviewFeed - Module Test', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockLoadReviews.mockResolvedValue({ reviews: [], pagination: { total_pages: 1 } });
+
+    // Моки компонентов должны возвращать валидный React элемент
+    mockReviewList.mockImplementation(() => <div data-testid="review-list">ReviewList Mock</div>);
+    mockButton.mockImplementation(({ onClick, children, loading }: any) => (
+      <button onClick={onClick} disabled={loading} data-testid="button">
+        {children}
+      </button>
+    ));
+    mockAlert.mockImplementation(({ children }: any) => <div data-testid="alert">{children}</div>);
+    mockSpinner.mockImplementation(() => <div data-testid="spinner">Spinner Mock</div>);
+  });
+
+  describe('логика параметров', () => {
+    it('передает authorId в loadReviews', async () => {
+      render(<ReviewFeed loadReviews={mockLoadReviews} authorId={123} />);
+
+      await waitFor(() => {
+        expect(mockLoadReviews).toHaveBeenCalledWith(expect.objectContaining({ author_id: 123 }));
+      });
+    });
+
+    it('не передает authorId если не указан', async () => {
+      render(<ReviewFeed loadReviews={mockLoadReviews} />);
+
+      await waitFor(() => {
+        expect(mockLoadReviews).toHaveBeenCalledWith(
+          expect.objectContaining({ author_id: undefined })
+        );
+      });
+    });
+
+    it('передает reviewCardProps в ReviewList', async () => {
+      const reviewCardProps = {
+        showLikes: false,
+        showStatus: false,
+        moderation: true,
+      };
+
+      render(<ReviewFeed loadReviews={mockLoadReviews} reviewCardProps={reviewCardProps} />);
+
+      await waitFor(() => {
+        const calls = mockReviewList.mock.calls;
+        expect(calls.length).toBeGreaterThan(0);
+        const lastCall = calls[calls.length - 1];
+        expect(lastCall[0]).toMatchObject({
+          cardProps: reviewCardProps,
+          reviews: [],
+          onLikeUpdate: expect.any(Function),
+        });
+      });
+    });
+  });
+
+  describe('логика withControls', () => {
+    it('не вызывает loadReviews с search/sort при withControls=false', async () => {
+      render(<ReviewFeed loadReviews={mockLoadReviews} withControls={false} />);
+
+      await waitFor(() => {
+        const call = mockLoadReviews.mock.calls[0][0];
+        expect(call.search).toBeUndefined();
+        expect(call.sort).toBeUndefined();
+        expect(call.order).toBeUndefined();
+      });
+    });
+    it('вызывает loadReviews с search/sort при withControls=true', async () => {
+      render(<ReviewFeed loadReviews={mockLoadReviews} withControls={true} />);
+
+      await waitFor(() => {
+        const call = mockLoadReviews.mock.calls[0][0];
+        expect(call.sort).toBe('created_at');
+        expect(call.order).toBe('desc');
+      });
+    });
+  });
+
+  describe('состояния загрузки и ошибки', () => {
+    it('показывает Spinner во время загрузки', async () => {
+      // Делаем загрузку медленной
+      mockLoadReviews.mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            setTimeout(() => resolve({ reviews: [], pagination: { total_pages: 1 } }), 100);
+          })
+      );
+
+      render(<ReviewFeed loadReviews={mockLoadReviews} />);
+
+      expect(screen.getByTestId('spinner')).toBeInTheDocument();
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
+      });
+    });
+    it('показывает Alert при ошибке загрузки', async () => {
+      const errorMessage = 'Ошибка сети';
+      mockLoadReviews.mockRejectedValue({ uiMessage: errorMessage });
+
+      render(<ReviewFeed loadReviews={mockLoadReviews} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('alert')).toHaveTextContent(errorMessage);
+      });
+    });
+  });
+
+  describe('пагинация', () => {
+    beforeEach(() => {
+      mockLoadReviews.mockResolvedValue({
+        reviews: [],
+        pagination: { total_pages: 3 },
+      });
+    });
+
+    it('показывает пагинацию при total_pages > 1', async () => {
+      render(<ReviewFeed loadReviews={mockLoadReviews} />);
+
+      await waitFor(() => {
+        expect(screen.getByTestId('review-list')).toBeInTheDocument();
+        expect(mockButton).toHaveBeenCalled();
+      });
+    });
+
+    it('не показывает пагинацию при total_pages = 1', async () => {
+      mockLoadReviews.mockResolvedValue({
+        reviews: [],
+        pagination: { total_pages: 1 },
+      });
+
+      render(<ReviewFeed loadReviews={mockLoadReviews} />);
+
+      await waitFor(() => {
+        // Кнопки пагинации не должны вызываться
+        const buttonCalls = mockButton.mock.calls;
+        const paginationButtonCalls = buttonCalls.filter(
+          (call: any) => call[0]?.children === '➡' || call[0]?.children === '⬅'
+        );
+        expect(paginationButtonCalls).toHaveLength(0);
+      });
+    });
+    it('меняет страницу при клике на кнопки', async () => {
+      render(<ReviewFeed loadReviews={mockLoadReviews} />);
+
+      await waitFor(() => {
+        expect(mockLoadReviews).toHaveBeenCalledWith(expect.objectContaining({ page: 1 }));
+      });
+
+      const buttonCalls = mockButton.mock.calls;
+      const nextButtonCall = buttonCalls.find((call: any) => call[0]?.children === '➡');
+
+      if (nextButtonCall && nextButtonCall[0]?.onClick) {
+        nextButtonCall[0].onClick();
+
+        await waitFor(() => {
+          expect(mockLoadReviews).toHaveBeenCalledWith(expect.objectContaining({ page: 2 }));
+        });
+      }
+    });
+
+    it('блокирует кнопки пагинации при loading', async () => {
+      render(<ReviewFeed loadReviews={mockLoadReviews} />);
+
+      await waitFor(() => {
+        const buttonCalls = mockButton.mock.calls;
+        const paginationButtons = buttonCalls.filter(
+          (call: any) => call[0]?.children === '➡' || call[0]?.children === '⬅'
+        );
+
+        paginationButtons.forEach((call: any) => {
+          expect(call[0].loading).toBe(false); // После загрузки loading=false
+        });
+      });
+    });
+  });
+
+  describe('логика handleLikeUpdate', () => {
+    it('обновляет лайки в reviews', async () => {
+      const mockReviews = [
+        {
+          id: 1,
+          title: 'Review 1',
+          movie_title: 'Movie 1',
+          content: 'Content 1',
+          likes: 10,
+          is_liked: false,
+          created_at: '2024-01-01',
+          status: 'approved',
+          author: { id: 1, username: 'user1' },
+        } as any,
+      ];
+
+      mockLoadReviews.mockResolvedValue({
+        reviews: mockReviews,
+        pagination: { total_pages: 1 },
+      });
+
+      let likeUpdateHandler: any;
+      mockReviewList.mockImplementation(({ onLikeUpdate }: any) => {
+        likeUpdateHandler = onLikeUpdate;
+        return <div data-testid="review-list">ReviewList</div>;
+      });
+
+      await act(async () => {
+        render(<ReviewFeed loadReviews={mockLoadReviews} />);
+      });
+
+      await waitFor(() => {
+        expect(likeUpdateHandler).toBeDefined();
+      });
+
+      // Вызываем обработчик обновления лайков
+      if (likeUpdateHandler) {
+        await act(async () => {
+          likeUpdateHandler(1, 11, true);
+        });
+
+        // Ждем обновления и проверяем последний вызов ReviewList
+        await waitFor(() => {
+          const calls = mockReviewList.mock.calls;
+          expect(calls.length).toBeGreaterThan(1);
+
+          // Ищем вызов с обновленными данными
+          const lastCall = calls[calls.length - 1];
+          const reviewsArg = lastCall[0].reviews;
+          const updatedReview = reviewsArg.find((r: any) => r.id === 1);
+
+          if (updatedReview) {
+            expect(updatedReview.likes).toBe(11);
+            expect(updatedReview.is_liked).toBe(true);
+          }
+        });
+      }
+    });
+  });
+});

--- a/frontend/src/components/ReviewList/ReviewList.test.tsx
+++ b/frontend/src/components/ReviewList/ReviewList.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../ReviewMiniCard', () => ({
+  ReviewMiniCard: ({ review }: any) => <div>{review.title}</div>,
+}));
+
+import { ReviewList } from './index';
+
+describe('ReviewList', () => {
+  it('показывает сообщение если пусто', () => {
+    render(<ReviewList reviews={[]} />);
+    expect(screen.getByText('Рецензии не найдены ☹')).toBeInTheDocument();
+  });
+
+  it('рендерит список карточек', () => {
+    const reviews = [
+      { id: 1, title: 'Test', content: '', status: 'approved' },
+      { id: 2, title: 'Test2', content: '', status: 'approved' },
+    ] as any;
+
+    render(<ReviewList reviews={reviews} />);
+
+    expect(screen.getByText('Test')).toBeInTheDocument();
+    expect(screen.getByText('Test2')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/ReviewMiniCard/ReviewMiniCard.test.tsx
+++ b/frontend/src/components/ReviewMiniCard/ReviewMiniCard.test.tsx
@@ -1,0 +1,100 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockFormatDate = vi.hoisted(() => vi.fn());
+const mockGetReviewRoute = vi.hoisted(() => vi.fn());
+const mockGetUserProfileRoute = vi.hoisted(() => vi.fn());
+const mockLikes = vi.hoisted(() => vi.fn());
+const mockLink = vi.hoisted(() => vi.fn());
+
+vi.mock('../../utils/date', () => ({
+  formatDate: mockFormatDate,
+}));
+
+vi.mock('../../lib/routes', () => ({
+  getReviewRoute: mockGetReviewRoute,
+  getUserProfileRoute: mockGetUserProfileRoute,
+}));
+
+vi.mock('../Likes', () => ({
+  Likes: mockLikes,
+}));
+
+vi.mock('react-router-dom', () => ({
+  Link: mockLink,
+}));
+
+vi.mock('./index.module.scss', () => ({
+  default: {
+    card: 'card',
+    title: 'title',
+    meta: 'meta',
+    movie: 'movie',
+    author: 'author',
+    date: 'date',
+    preview: 'preview',
+    status: 'status',
+  },
+}));
+
+import { ReviewMiniCard } from './index';
+
+describe('ReviewMiniCard', () => {
+  const mockReview = {
+    id: 1,
+    title: 'Title',
+    movie_title: 'Movie',
+    content: 'Content text',
+    created_at: '2024-01-01',
+    likes: 5,
+    is_liked: false,
+    status: 'approved',
+    author: {
+      id: 1,
+      username: 'user',
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockFormatDate.mockReturnValue('1 января 2024');
+    mockGetReviewRoute.mockReturnValue('/review/1');
+    mockGetUserProfileRoute.mockReturnValue('/user/1');
+
+    mockLikes.mockReturnValue(<div data-testid="likes">Likes</div>);
+    mockLink.mockImplementation(({ to, children, className }: any) => (
+      <a href={to} className={className} data-testid="link">
+        {children}
+      </a>
+    ));
+  });
+
+  it('рендерит данные рецензии', () => {
+    render(<ReviewMiniCard review={mockReview as any} />);
+
+    expect(screen.getByText('Title')).toBeInTheDocument();
+    expect(screen.getByText('Movie')).toBeInTheDocument();
+    expect(screen.getByText('user')).toBeInTheDocument();
+    expect(screen.getByText('1 января 2024')).toBeInTheDocument();
+  });
+
+  it('показывает Likes при status=approved', () => {
+    render(<ReviewMiniCard review={mockReview as any} />);
+
+    expect(screen.getByTestId('likes')).toBeInTheDocument();
+  });
+
+  it('не показывает Likes при status=pending', () => {
+    const pendingReview = { ...mockReview, status: 'pending' as const };
+    render(<ReviewMiniCard review={pendingReview as any} />);
+
+    expect(screen.queryByTestId('likes')).not.toBeInTheDocument();
+  });
+
+  it('не показывает Likes при showLikes=false', () => {
+    render(<ReviewMiniCard review={mockReview as any} showLikes={false} />);
+
+    expect(screen.queryByTestId('likes')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Добавлены модульные тесты для всех основных React-компонентов проекта.

Что протестировано:

Базовые компоненты UI:
- **`Alert`** - отображение уведомлений
- **`Button`** / **`LinkButton`** - кнопки и ссылки-кнопки
- **`Input`** - поле ввода с валидацией
- **`Spinner`** - индикатор загрузки
- **`DeleteConfirmModal`** - модальное окно подтверждения удаления

Компоненты навигации и лейаута:
- **`Navbar`** - навигационная панель с учетом авторизации
- **`MainLayout`** - основной лейаут приложения
- **`ProtectedRoutes`** - защищенные маршруты

Компоненты для работы с рецензиями:
- **`ReviewCard`** - полная карточка рецензии
- **`ReviewMiniCard`** - компактная карточка рецензии  
- **`ReviewList`** - список рецензий
- **`ReviewFeed`** - лента рецензий с пагинацией и фильтрацией
- **`Likes`** - компонент лайков с optimistic updates

Особенности тестирования:

- **Изоляция зависимостей** - все внешние модули (API, контексты, роутинг) замоканы
- **Проверка состояний** - тестирование всех возможных состояний компонентов
- **Обработка событий** - тестирование кликов, ввода данных, отправки форм
- **Логика условий** - проверка условного рендеринга (авторизация, роли, статусы)

Closes #95 