### PR TITLE
Test: add unit tests for pages

### DIFF
--- a/frontend/src/lib/routes.test.ts
+++ b/frontend/src/lib/routes.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import * as routes from './routes';
+
+describe('routes', () => {
+  it('review route', () => {
+    expect(routes.getReviewRoute(1)).toBe('/reviews/1');
+  });
+
+  it('moderation route', () => {
+    expect(routes.getReviewRoute(1, { mode: 'moderation' })).toBe('/reviews/1?mode=moderation');
+  });
+
+  it('user profile', () => {
+    expect(routes.getUserProfileRoute(5)).toBe('/users/5');
+  });
+});

--- a/frontend/src/pages/CreateReviewPage/CreateReviewPage.test.tsx
+++ b/frontend/src/pages/CreateReviewPage/CreateReviewPage.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { CreateReviewPage } from './index';
+import * as reviewsApi from '../../api/reviews';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../api/reviews', () => ({
+  createReview: vi.fn(),
+}));
+
+describe('CreateReviewPage', () => {
+  const mockCreateReview = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(reviewsApi.createReview).mockImplementation(mockCreateReview);
+  });
+
+  it('рендерит форму создания рецензии', () => {
+    render(
+      <MemoryRouter>
+        <CreateReviewPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Новая рецензия')).toBeInTheDocument();
+    expect(screen.getByLabelText(/заголовок рецензии/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/название фильма/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Введите текст рецензии...')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /отправить на модерацию/i })).toBeInTheDocument();
+  });
+
+  it('показывает ошибки валидации при слишком коротких полях', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <CreateReviewPage />
+      </MemoryRouter>
+    );
+
+    const titleInput = screen.getByLabelText(/заголовок рецензии/i);
+    const movieInput = screen.getByLabelText(/название фильма/i);
+    const contentTextarea = screen.getByPlaceholderText('Введите текст рецензии...');
+
+    await act(async () => {
+      await user.type(titleInput, 'abc');
+      await user.type(movieInput, 'film');
+      await user.type(contentTextarea, 'короткий');
+    });
+
+    await waitFor(() => {
+      const min5Errors = screen.getAllByText('Минимум 5 символов');
+      expect(min5Errors).toHaveLength(2); // для title и movie_title
+      expect(screen.getByText('Минимум 100 символов')).toBeInTheDocument();
+    });
+  });
+
+  it('успешно отправляет форму → перенаправляет на страницу рецензии', async () => {
+    const user = userEvent.setup();
+    mockCreateReview.mockResolvedValueOnce({ id: 123 });
+
+    render(
+      <MemoryRouter>
+        <CreateReviewPage />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      await user.type(screen.getByLabelText(/заголовок рецензии/i), 'Отличный фильм 2025');
+      await user.type(screen.getByLabelText(/название фильма/i), 'Dune: Part Three');
+
+      const longText =
+        'Это очень длинный и осмысленный текст рецензии, который должен пройти валидацию по длине и символам. '.repeat(
+          3
+        );
+      await user.type(screen.getByPlaceholderText('Введите текст рецензии...'), longText);
+
+      await user.click(screen.getByRole('button', { name: /отправить на модерацию/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockCreateReview).toHaveBeenCalledTimes(1);
+      expect(mockNavigate).toHaveBeenCalledWith('/reviews/123');
+    });
+  });
+
+  it('показывает серверную ошибку и не перенаправляет при неудаче', async () => {
+    const user = userEvent.setup();
+    mockCreateReview.mockRejectedValueOnce({ uiMessage: 'Ошибка сервера, попробуйте позже' });
+
+    render(
+      <MemoryRouter>
+        <CreateReviewPage />
+      </MemoryRouter>
+    );
+
+    await act(async () => {
+      await user.type(screen.getByLabelText(/заголовок рецензии/i), 'Тестовая рецензия');
+      await user.type(screen.getByLabelText(/название фильма/i), 'Тестовый фильм');
+
+      const longText =
+        'Достаточно длинный текст для прохождения валидации и теста отправки. '.repeat(4);
+      await user.type(screen.getByPlaceholderText('Введите текст рецензии...'), longText);
+
+      await user.click(screen.getByRole('button', { name: /отправить на модерацию/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Ошибка сервера, попробуйте позже')).toBeInTheDocument();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/EditReviewPage/EditReviewPage.test.tsx
+++ b/frontend/src/pages/EditReviewPage/EditReviewPage.test.tsx
@@ -1,0 +1,229 @@
+import { render, screen, waitFor, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { EditReviewPage } from './index';
+import * as reviewsApi from '../../api/reviews';
+import * as AuthContext from '../../context/AuthContext';
+import type { User } from '../../api/types';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+    useParams: vi.fn(() => ({ reviewId: '42' })),
+  };
+});
+
+vi.mock('../../api/reviews', () => ({
+  getReviewById: vi.fn(),
+  updateReview: vi.fn(),
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+  ...vi.importActual('../../context/AuthContext'),
+  useMe: vi.fn(),
+}));
+
+const mockCurrentUser: User = {
+  id: 10,
+  username: 'testuser',
+  role: 'user',
+};
+
+const mockAnotherUser: User = {
+  id: 999,
+  username: 'another',
+  role: 'user',
+};
+
+const mockReview = {
+  id: 42,
+  title: 'Старый заголовок',
+  movie_title: 'Старый фильм',
+  content: 'Старый длинный текст рецензии, который уже больше 100 символов. '.repeat(4),
+  author: { id: 10 },
+};
+
+async function userAct(user: ReturnType<typeof userEvent.setup>, fn: () => Promise<void>) {
+  await act(async () => {
+    await fn();
+  });
+}
+
+describe('EditReviewPage', () => {
+  const mockGetReviewById = vi.fn();
+  const mockUpdateReview = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(reviewsApi.getReviewById).mockImplementation(mockGetReviewById);
+    vi.mocked(reviewsApi.updateReview).mockImplementation(mockUpdateReview);
+
+    vi.mocked(AuthContext.useMe).mockReturnValue(mockCurrentUser);
+  });
+
+  it('показывает спиннер при загрузке рецензии', async () => {
+    mockGetReviewById.mockImplementation(() => new Promise(() => {})); // зависание
+
+    render(
+      <MemoryRouter initialEntries={['/reviews/42/edit']}>
+        <Routes>
+          <Route path="/reviews/:reviewId/edit" element={<EditReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      const spinner = document.querySelector('[class*="_spinner"]');
+      expect(spinner).toBeInTheDocument();
+    });
+  });
+
+  it('показывает ошибку, если рецензия не найдена или нет прав', async () => {
+    mockGetReviewById.mockRejectedValueOnce({ uiMessage: 'Рецензия не найдена' });
+
+    render(
+      <MemoryRouter initialEntries={['/reviews/42/edit']}>
+        <Routes>
+          <Route path="/reviews/:reviewId/edit" element={<EditReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Рецензия не найдена')).toBeInTheDocument();
+    });
+  });
+
+  it('показывает ошибку, если пользователь не автор рецензии', async () => {
+    vi.mocked(AuthContext.useMe).mockReturnValue(mockAnotherUser);
+
+    mockGetReviewById.mockResolvedValueOnce(mockReview);
+
+    render(
+      <MemoryRouter initialEntries={['/reviews/42/edit']}>
+        <Routes>
+          <Route path="/reviews/:reviewId/edit" element={<EditReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('У вас нет прав на редактирование этой рецензии')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('предзаполняет форму данными рецензии и позволяет редактировать', async () => {
+    const user = userEvent.setup();
+
+    mockGetReviewById.mockResolvedValueOnce(mockReview);
+
+    render(
+      <MemoryRouter initialEntries={['/reviews/42/edit']}>
+        <Routes>
+          <Route path="/reviews/:reviewId/edit" element={<EditReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Старый заголовок')).toBeInTheDocument();
+      expect(screen.getByDisplayValue('Старый фильм')).toBeInTheDocument();
+    });
+
+    const contentTextarea = screen.getByRole('textbox', { name: '' });
+    const initialLength = mockReview.content.length;
+
+    await userAct(user, async () => {
+      await user.type(contentTextarea, ' Дополнение!!!');
+    });
+
+    await waitFor(() => {
+      const expectedLength = initialLength + ' Дополнение!!!'.length;
+      expect(screen.getByText(`${expectedLength} / 5000`)).toBeInTheDocument();
+    });
+
+    const titleInput = screen.getByDisplayValue('Старый заголовок');
+    await userAct(user, async () => {
+      await user.clear(titleInput);
+      await user.type(titleInput, 'Новый заголовок 2026');
+    });
+  });
+
+  it('успешно обновляет рецензию и перенаправляет', async () => {
+    const user = userEvent.setup();
+
+    mockGetReviewById.mockResolvedValueOnce(mockReview);
+    mockUpdateReview.mockResolvedValueOnce({ id: 42 });
+
+    render(
+      <MemoryRouter initialEntries={['/reviews/42/edit']}>
+        <Routes>
+          <Route path="/reviews/:reviewId/edit" element={<EditReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByDisplayValue('Старый заголовок')).toBeInTheDocument();
+    });
+
+    await userAct(user, async () => {
+      await user.clear(screen.getByLabelText(/заголовок рецензии/i));
+      await user.type(screen.getByLabelText(/заголовок рецензии/i), 'Обновлённый заголовок');
+
+      await user.clear(screen.getByLabelText(/название фильма/i));
+      await user.type(screen.getByLabelText(/название фильма/i), 'Обновлённый фильм');
+
+      await user.click(screen.getByRole('button', { name: /отправить на модерацию/i }));
+    });
+
+    await waitFor(() => {
+      expect(mockUpdateReview).toHaveBeenCalledWith(
+        42,
+        'Обновлённый заголовок',
+        'Обновлённый фильм',
+        expect.any(String)
+      );
+      expect(mockNavigate).toHaveBeenCalledWith('/reviews/42');
+    });
+  });
+
+  it('показывает серверную ошибку при неудачном обновлении', async () => {
+    const user = userEvent.setup();
+
+    mockGetReviewById.mockResolvedValueOnce(mockReview);
+    mockUpdateReview.mockRejectedValueOnce({ uiMessage: 'Не удалось обновить' });
+
+    render(
+      <MemoryRouter initialEntries={['/reviews/42/edit']}>
+        <Routes>
+          <Route path="/reviews/:reviewId/edit" element={<EditReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    // Ждём появления кнопки "Отправить на модерацию"
+    const submitButton = await screen.findByRole('button', {
+      name: /отправить на модерацию/i,
+    });
+
+    // Клик через act
+    await act(async () => {
+      await user.click(submitButton);
+    });
+
+    // Ждём появления ошибки
+    await waitFor(() => {
+      expect(screen.getByText('Не удалось обновить')).toBeInTheDocument();
+      expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/frontend/src/pages/ReviewPage/ReviewPage.test.tsx
+++ b/frontend/src/pages/ReviewPage/ReviewPage.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, it, vi, expect } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { ReviewPage } from './index';
+import * as apiReviews from '../../api/reviews';
+import { useMe } from '../../context/AuthContext';
+
+vi.mock('./index.module.scss', () => ({ default: {} }));
+vi.mock('../../components/ReviewCard', () => ({
+  ReviewCard: ({ review, ...props }: any) => (
+    <div>
+      ReviewCard {review?.id} {review?.title || ''}
+      {props.actionError && <div>{props.actionError}</div>}
+      {props.deleteError && <div>{props.deleteError}</div>}
+    </div>
+  ),
+}));
+vi.mock('../../components/Spinner', () => ({ Spinner: () => <div>Loading...</div> }));
+vi.mock('../../components/Alert', () => ({
+  Alert: ({ children }: any) => <div>Alert: {children}</div>,
+}));
+vi.mock('../../components/DeleteConfirmModal', () => ({
+  DeleteConfirmModal: ({ isOpen, onConfirm, onCancel }: any) =>
+    isOpen ? (
+      <button onClick={onConfirm}>Confirm Delete</button>
+    ) : (
+      <button onClick={onCancel}>Cancel Delete</button>
+    ),
+}));
+
+vi.mock('../../api/reviews', () => ({
+  getReviewById: vi.fn(),
+  approveReview: vi.fn(),
+  rejectReview: vi.fn(),
+  deleteReview: vi.fn(),
+}));
+
+vi.mock('../../context/AuthContext', () => ({
+  useMe: vi.fn(),
+}));
+
+describe('ReviewPage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('показывает спиннер при загрузке', () => {
+    (apiReviews.getReviewById as any).mockReturnValue(new Promise(() => {})); // никогда не резолвится
+
+    render(
+      <MemoryRouter initialEntries={['/review/1']}>
+        <Routes>
+          <Route path="/review/:reviewId" element={<ReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('рендерит данные рецензии после успешного запроса', async () => {
+    const mockReview = { id: 1, title: 'Test Review', author: { id: 2 } };
+    (apiReviews.getReviewById as any).mockResolvedValue(mockReview);
+    (useMe as any).mockReturnValue({ id: 2, role: 'user' });
+
+    render(
+      <MemoryRouter initialEntries={['/review/1']}>
+        <Routes>
+          <Route path="/review/:reviewId" element={<ReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.queryByText('Loading...')).not.toBeInTheDocument());
+
+    expect(screen.getByText(/ReviewCard 1/)).toBeInTheDocument();
+  });
+
+  it('показывает ошибку при некорректном reviewId', async () => {
+    render(
+      <MemoryRouter initialEntries={['/review/abc']}>
+        <Routes>
+          <Route path="/review/:reviewId" element={<ReviewPage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(screen.getByText(/Некорректный id рецензии/i)).toBeInTheDocument());
+  });
+});

--- a/frontend/src/pages/SignInPage/SignInPage.test.tsx
+++ b/frontend/src/pages/SignInPage/SignInPage.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { SignInPage } from './index';
+import * as AuthContext from '../../context/AuthContext';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../context/AuthContext', () => ({
+  ...vi.importActual('../../context/AuthContext'),
+  useAuth: vi.fn(),
+}));
+
+describe('SignInPage', () => {
+  const mockLogin = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(AuthContext.useAuth).mockReturnValue({
+      login: mockLogin,
+    } as any);
+  });
+
+  it('рендерит форму входа', () => {
+    render(
+      <MemoryRouter>
+        <SignInPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText(/логин/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/пароль/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /войти/i })).toBeInTheDocument();
+  });
+
+  it('показывает ошибку валидации при слишком коротком username', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <SignInPage />
+      </MemoryRouter>
+    );
+
+    const usernameInput = screen.getByLabelText(/логин/i);
+    await user.type(usernameInput, 'abc');
+    await user.tab();
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Минимум 4 символа')).toBeInTheDocument();
+      },
+      { timeout: 1500 }
+    );
+  });
+
+  it('успешный вход → перенаправление на главную', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <SignInPage />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/логин/i), 'validuser123');
+    await user.type(screen.getByLabelText(/пароль/i), 'Password123!');
+
+    await user.click(screen.getByRole('button', { name: /войти/i }));
+
+    await waitFor(
+      () => {
+        expect(mockLogin).toHaveBeenCalledWith('validuser123', 'Password123!');
+        expect(mockNavigate).toHaveBeenCalledWith('/');
+      },
+      { timeout: 1500 }
+    );
+  });
+
+  it('показывает серверную ошибку при неудачном входе', async () => {
+    mockLogin.mockRejectedValueOnce({ uiMessage: 'Неверный логин или пароль' });
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <SignInPage />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/логин/i), 'wronguser');
+    await user.type(screen.getByLabelText(/пароль/i), 'WrongPass123!');
+
+    await user.click(screen.getByRole('button', { name: /войти/i }));
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Неверный логин или пароль')).toBeInTheDocument();
+      },
+      { timeout: 1500 }
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/SignUpPage/SignUpPage.test.tsx
+++ b/frontend/src/pages/SignUpPage/SignUpPage.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MemoryRouter } from 'react-router-dom';
+import { SignUpPage } from './index';
+import * as AuthContext from '../../context/AuthContext';
+
+const mockNavigate = vi.fn();
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+vi.mock('../../context/AuthContext', () => ({
+  ...vi.importActual('../../context/AuthContext'),
+  useAuth: vi.fn(),
+}));
+
+describe('SignUpPage', () => {
+  const mockRegister = vi.fn().mockResolvedValue(undefined);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    vi.mocked(AuthContext.useAuth).mockReturnValue({
+      register: mockRegister,
+    } as any);
+  });
+
+  it('рендерит форму регистрации', () => {
+    render(
+      <MemoryRouter>
+        <SignUpPage />
+      </MemoryRouter>
+    );
+
+    expect(screen.getByLabelText(/логин/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/пароль/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /зарегистрироваться/i })).toBeInTheDocument();
+  });
+
+  it('показывает ошибку валидации при слишком коротком username', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <SignUpPage />
+      </MemoryRouter>
+    );
+
+    const usernameInput = screen.getByLabelText(/логин/i);
+    await user.type(usernameInput, 'abc');
+    await user.tab();
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Минимум 4 символа')).toBeInTheDocument();
+      },
+      { timeout: 1500 }
+    );
+  });
+
+  it('успешная регистрация → перенаправление на главную', async () => {
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <SignUpPage />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/логин/i), 'validuser123');
+    await user.type(screen.getByLabelText(/пароль/i), 'Password123!');
+
+    await user.click(screen.getByRole('button', { name: /зарегистрироваться/i }));
+
+    await waitFor(
+      () => {
+        expect(mockRegister).toHaveBeenCalledWith('validuser123', 'Password123!');
+        expect(mockNavigate).toHaveBeenCalledWith('/');
+      },
+      { timeout: 1500 }
+    );
+  });
+
+  it('показывает серверную ошибку при неудачной регистрации', async () => {
+    mockRegister.mockRejectedValueOnce({ uiMessage: 'Пользователь уже существует' });
+
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <SignUpPage />
+      </MemoryRouter>
+    );
+
+    await user.type(screen.getByLabelText(/логин/i), 'existinguser');
+    await user.type(screen.getByLabelText(/пароль/i), 'ValidPass123!');
+
+    await user.click(screen.getByRole('button', { name: /зарегистрироваться/i }));
+
+    await waitFor(
+      () => {
+        expect(screen.getByText('Пользователь уже существует')).toBeInTheDocument();
+      },
+      { timeout: 1500 }
+    );
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/pages/UserProfilePage/UserProfilePage.test.tsx
+++ b/frontend/src/pages/UserProfilePage/UserProfilePage.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { UserProfilePage } from './index';
+import * as apiUsers from '../../api/users';
+
+vi.mock('./index.module.scss', () => ({
+  default: {},
+}));
+
+vi.mock('../../components/ReviewFeed', () => ({
+  ReviewFeed: ({ authorId }: { authorId: number }) => <div>ReviewFeed {authorId}</div>,
+}));
+
+vi.mock('../../components/Spinner', () => ({
+  Spinner: () => <div>Loading...</div>,
+}));
+
+vi.mock('../../components/Alert', () => ({
+  Alert: ({ children }: any) => <div>Alert: {children}</div>,
+}));
+
+vi.mock('../../api/users', () => ({
+  getUserById: vi.fn(),
+}));
+
+describe('UserProfilePage', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('показывает спиннер при загрузке', () => {
+    render(
+      <MemoryRouter initialEntries={['/user/1']}>
+        <Routes>
+          <Route path="/user/:userId" element={<UserProfilePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('рендерит данные пользователя после успешного запроса', async () => {
+    const mockUser = { id: 1, username: 'testuser' };
+    vi.mocked(apiUsers.getUserById).mockResolvedValueOnce(mockUser);
+
+    render(
+      <MemoryRouter initialEntries={['/user/1']}>
+        <Routes>
+          <Route path="/user/:userId" element={<UserProfilePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(mockUser.username)).toBeInTheDocument();
+
+    expect(screen.getByText(/Рецензии пользователя/i)).toBeInTheDocument();
+    expect(screen.getByText(`ReviewFeed ${mockUser.id}`)).toBeInTheDocument();
+  });
+
+  it('показывает ошибку при некорректном userId', async () => {
+    render(
+      <MemoryRouter initialEntries={['/user/abc']}>
+        <Routes>
+          <Route path="/user/:userId" element={<UserProfilePage />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText(/Некорректный id пользователя/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Добавлены модульные тесты для ключевых страниц React-приложения с использованием Vitest и React Testing Library.
Тесты проверяют корректность логики страниц, обработку состояний и взаимодействие с API через моки.
Добавлены тесты для 6 страниц:
- CreateReviewPage — создание новой рецензии
- EditReviewPage — редактирование рецензии
- ReviewPage — отображение рецензии
- SignInPage — авторизация
- SignUpPage — регистрация
- UserProfilePage — профиль пользователя

Closes #97 